### PR TITLE
Use fopina CycleTLS fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	h12.io/socks v1.0.3 // indirect
 )
+
+replace github.com/Danny-Dasilva/CycleTLS/cycletls => github.com/fopina/CycleTLS/cycletls v0.0.0-20260606182123-283dde567e9e

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Danny-Dasilva/CycleTLS/cycletls v1.0.30 h1:MUrYvIPkb4D83p16LKt7csGjhAF2JIeCdjtzhjm7doY=
-github.com/Danny-Dasilva/CycleTLS/cycletls v1.0.30/go.mod h1:uLgl93R8am9dUvj+9pAI3pTwsmRKmFeWzz3eaN9HrQw=
 github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131 h1:gRgU8L1jIWP8noBJk8p1mD3JSJNVDB3HNncjKT6SAFg=
 github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131/go.mod h1:Hvab/V/YKCDXsEpKYKHjAXH5IFOmoq9FsfxjztEqvDc=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
@@ -33,6 +31,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
+github.com/fopina/CycleTLS/cycletls v0.0.0-20260606182123-283dde567e9e h1:xVVqrjg2g4QcwU9VzmmZuuouEXY5EETdwVPsonQpSNs=
+github.com/fopina/CycleTLS/cycletls v0.0.0-20260606182123-283dde567e9e/go.mod h1:GISoO+v+KLjZ3GQbXmNMrhULWzH//72k/Gm5f+J/D74=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=


### PR DESCRIPTION
## Summary
- replace CycleTLS module source with github.com/fopina/CycleTLS/cycletls
- keep existing import path while using fork with header casing preservation

## Tests
- env GOCACHE=/Users/fopina/workspace/gotlsproxy/.gocache go test ./...