### PR TITLE
Fix response header forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ $ docker run --rm ghcr.io/fopina/gotlsproxy:0.3 -version
 0.3
 ```
 
+### Response handling
+
+`gotlsproxy` uses CycleTLS for upstream requests. CycleTLS may decode compressed upstream response bodies before returning them to the proxy, so responses sent back to clients are the decoded body, not necessarily the original wire-encoded bytes. With the current CycleTLS version, `gzip`, `deflate`, `br`, and `brotli` response encodings are decoded when advertised by the upstream `Content-Encoding` header.
+
+Because of that, `gotlsproxy` forwards upstream response headers except `Content-Encoding` and `Content-Length`. Those two headers describe the original upstream representation and can become stale after decoding; Go's HTTP server will frame the response body sent to the client.
+
 ### Validation
 
 We can use an online service to validate that JA3 fingerprint does change, such as https://ja3.zone/check

--- a/main.go
+++ b/main.go
@@ -55,6 +55,19 @@ func printIfErrorCode(request *http.Request, response *cycletls.Response) {
 	}
 }
 
+func copyResponseHeaders(dst http.Header, src map[string]string) {
+	for name, value := range src {
+		switch {
+		case strings.EqualFold(name, "Content-Encoding"):
+			continue
+		case strings.EqualFold(name, "Content-Length"):
+			continue
+		}
+
+		dst.Add(name, value)
+	}
+}
+
 func hello(w http.ResponseWriter, req *http.Request) {
 	client := cycletls.Init()
 
@@ -93,11 +106,8 @@ func hello(w http.ResponseWriter, req *http.Request) {
 		printIfErrorCode(req, &response)
 	}
 
+	copyResponseHeaders(w.Header(), response.Headers)
 	w.WriteHeader(response.Status)
-	for name, h := range response.Headers {
-		w.Header().Add(name, h)
-	}
-
 	_, err = w.Write([]byte(response.Body))
 	if err != nil {
 		log.Printf("ERROR Proxy2Client: %v", err)

--- a/main_test.go
+++ b/main_test.go
@@ -135,6 +135,34 @@ Error 404 (Not Found)!!1
 The requested URL /asdasdasd was not found on this server.  That’s all we know.`, cleanError)
 }
 
+func TestCopyResponseHeaders(t *testing.T) {
+	headers := make(http.Header)
+
+	copyResponseHeaders(headers, map[string]string{
+		"Content-Type":  "application/json",
+		"Set-Cookie":    "session=abc; HttpOnly",
+		"Cache-Control": "no-store",
+	})
+
+	assert.Equal(t, "application/json", headers.Get("Content-Type"))
+	assert.Equal(t, []string{"session=abc; HttpOnly"}, headers.Values("Set-Cookie"))
+	assert.Equal(t, "no-store", headers.Get("Cache-Control"))
+}
+
+func TestCopyResponseHeadersDropsDecodedBodyEntityHeaders(t *testing.T) {
+	headers := make(http.Header)
+
+	copyResponseHeaders(headers, map[string]string{
+		"content-encoding": "gzip",
+		"CONTENT-LENGTH":   "123",
+		"Content-Type":     "text/plain",
+	})
+
+	assert.Empty(t, headers.Values("Content-Encoding"))
+	assert.Empty(t, headers.Values("Content-Length"))
+	assert.Equal(t, "text/plain", headers.Get("Content-Type"))
+}
+
 func TestScrapflyJA3Smoke(t *testing.T) {
 	if os.Getenv("GOTLSPROXY_SCRAPFLY_SMOKE") != "1" {
 		t.Skip("set GOTLSPROXY_SCRAPFLY_SMOKE=1 to run Scrapfly JA3 smoke test")


### PR DESCRIPTION
## Summary
- copy upstream response headers before writing the response status
- drop stale Content-Encoding and Content-Length after CycleTLS response body decoding
- document decoded response handling in the README

## Tests
- GOCACHE=/Users/fopina/workspace/gotlsproxy/.gocache go test ./...

Addresses the first two High findings in #23.