### PR TITLE
Strip hop-by-hop request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Flags:
     	Listening address to bind to (default "127.0.0.1:8888")
   -ja3 string
     	JA3 token to spoof, should align with user-agent (default "771,4865-4867-4866-49195-49199-52393-52392-49196-49200-49162-49161-49171-49172-51-57-47-53-10,0-23-65281-10-11-35-16-5-51-43-13-45-28-21,29-23-24-25-256-257,0")
+  -keep-request-header value
+    	Request header to forward even if normally stripped; can be used multiple times
   -print-errors
     	Print request and response when an error (4xx and 5xx) is returned from upstream server
   -timeout int
@@ -43,6 +45,18 @@ $ docker run --rm ghcr.io/fopina/gotlsproxy:0.3 -version
 `gotlsproxy` uses CycleTLS for upstream requests. CycleTLS may decode compressed upstream response bodies before returning them to the proxy, so responses sent back to clients are the decoded body, not necessarily the original wire-encoded bytes. With the current CycleTLS version, `gzip`, `deflate`, `br`, and `brotli` response encodings are decoded when advertised by the upstream `Content-Encoding` header.
 
 Because of that, `gotlsproxy` forwards upstream response headers except `Content-Encoding` and `Content-Length`. Those two headers describe the original upstream representation and can become stale after decoding; Go's HTTP server will frame the response body sent to the client.
+
+### Request header handling
+
+`gotlsproxy` strips hop-by-hop and proxy-sensitive request headers before forwarding requests upstream. This includes `Connection`, `Keep-Alive`, `Proxy-Authenticate`, `Proxy-Authorization`, `Proxy-Connection`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`, and any custom headers named by the request `Connection` header.
+
+If an upstream server requires one of those headers, use `-keep-request-header` to forward it anyway. The flag can be used multiple times:
+
+```
+$ gotlsproxy -keep-request-header Upgrade -keep-request-header Connection https://example.com/
+```
+
+The client `User-Agent` header is still not forwarded; use `-ua` to control the upstream user agent.
 
 ### Validation
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var listenAddress string
 var timeout int
 var printErrors bool
 var upstreamProxy string
+var keepRequestHeaders headerNames
 
 func writeError(w http.ResponseWriter, err error) {
 	w.WriteHeader(500)
@@ -80,6 +81,30 @@ var hopByHopRequestHeaders = map[string]struct{}{
 	"upgrade":             {},
 }
 
+type headerNames []string
+
+func (headers *headerNames) String() string {
+	return strings.Join(*headers, ",")
+}
+
+func (headers *headerNames) Set(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("header name cannot be empty")
+	}
+
+	*headers = append(*headers, value)
+	return nil
+}
+
+func (headers headerNames) allowList() map[string]struct{} {
+	allowList := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		allowList[strings.ToLower(header)] = struct{}{}
+	}
+	return allowList
+}
+
 func requestConnectionHeaders(headers http.Header) map[string]struct{} {
 	connectionHeaders := make(map[string]struct{})
 
@@ -95,7 +120,7 @@ func requestConnectionHeaders(headers http.Header) map[string]struct{} {
 	return connectionHeaders
 }
 
-func copyRequestHeaders(src http.Header) map[string]string {
+func copyRequestHeaders(src http.Header, keepHeaders map[string]struct{}) map[string]string {
 	forwardedHeaders := make(map[string]string)
 	connectionHeaders := requestConnectionHeaders(src)
 
@@ -104,11 +129,13 @@ func copyRequestHeaders(src http.Header) map[string]string {
 		if strings.EqualFold(name, "User-Agent") {
 			continue
 		}
-		if _, ok := hopByHopRequestHeaders[headerName]; ok {
-			continue
-		}
-		if _, ok := connectionHeaders[headerName]; ok {
-			continue
+		if _, keep := keepHeaders[headerName]; !keep {
+			if _, ok := hopByHopRequestHeaders[headerName]; ok {
+				continue
+			}
+			if _, ok := connectionHeaders[headerName]; ok {
+				continue
+			}
 		}
 		if len(values) == 0 {
 			continue
@@ -136,7 +163,7 @@ func hello(w http.ResponseWriter, req *http.Request) {
 		Body:      string(body),
 		Ja3:       ja3,
 		UserAgent: userAgent,
-		Headers:   copyRequestHeaders(req.Header),
+		Headers:   copyRequestHeaders(req.Header, keepRequestHeaders.allowList()),
 		Timeout:   timeout,
 		Proxy:     upstreamProxy,
 	}, req.Method)
@@ -164,6 +191,7 @@ func main() {
 	flag.StringVar(&upstreamProxy, "upstream-proxy", "", "Upstream proxy (if any required)")
 	flag.IntVar(&timeout, "timeout", 60, "Request timeout")
 	flag.BoolVar(&printErrors, "print-errors", false, "Print request and response when an error (4xx and 5xx) is returned from upstream server")
+	flag.Var(&keepRequestHeaders, "keep-request-header", "Request header to forward even if normally stripped; can be used multiple times")
 	versionPtr := flag.Bool("version", false, "display version")
 
 	flag.Usage = func() {

--- a/main.go
+++ b/main.go
@@ -68,6 +68,61 @@ func copyResponseHeaders(dst http.Header, src map[string]string) {
 	}
 }
 
+var hopByHopRequestHeaders = map[string]struct{}{
+	"connection":          {},
+	"keep-alive":          {},
+	"proxy-authenticate":  {},
+	"proxy-authorization": {},
+	"proxy-connection":    {},
+	"te":                  {},
+	"trailer":             {},
+	"transfer-encoding":   {},
+	"upgrade":             {},
+}
+
+func requestConnectionHeaders(headers http.Header) map[string]struct{} {
+	connectionHeaders := make(map[string]struct{})
+
+	for _, headerValue := range headers.Values("Connection") {
+		for _, headerName := range strings.Split(headerValue, ",") {
+			headerName = strings.ToLower(strings.TrimSpace(headerName))
+			if headerName != "" {
+				connectionHeaders[headerName] = struct{}{}
+			}
+		}
+	}
+
+	return connectionHeaders
+}
+
+func copyRequestHeaders(src http.Header) map[string]string {
+	forwardedHeaders := make(map[string]string)
+	connectionHeaders := requestConnectionHeaders(src)
+
+	for name, values := range src {
+		headerName := strings.ToLower(name)
+		if strings.EqualFold(name, "User-Agent") {
+			continue
+		}
+		if _, ok := hopByHopRequestHeaders[headerName]; ok {
+			continue
+		}
+		if _, ok := connectionHeaders[headerName]; ok {
+			continue
+		}
+		if len(values) == 0 {
+			continue
+		}
+		// cycleTLS does not support multiple values for an header
+		if len(values) > 1 {
+			log.Printf("WARNING: header %s had all values dropped but 1", name)
+		}
+		forwardedHeaders[name] = values[0]
+	}
+
+	return forwardedHeaders
+}
+
 func hello(w http.ResponseWriter, req *http.Request) {
 	client := cycletls.Init()
 
@@ -77,23 +132,11 @@ func hello(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	forwardedHeaders := make(map[string]string)
-	for k, v := range req.Header {
-		if k == "User-Agent" {
-			continue
-		}
-		// cycleTLS does not support multiple values for an header
-		if len(v) > 1 {
-			log.Printf("WARNING: header %s had all values dropped but 1", k)
-		}
-		forwardedHeaders[k] = v[0]
-	}
-
 	response, err := client.Do(fmt.Sprintf("%s%s", mainURL, req.URL), cycletls.Options{
 		Body:      string(body),
 		Ja3:       ja3,
 		UserAgent: userAgent,
-		Headers:   forwardedHeaders,
+		Headers:   copyRequestHeaders(req.Header),
 		Timeout:   timeout,
 		Proxy:     upstreamProxy,
 	}, req.Method)

--- a/main_test.go
+++ b/main_test.go
@@ -163,6 +163,59 @@ func TestCopyResponseHeadersDropsDecodedBodyEntityHeaders(t *testing.T) {
 	assert.Equal(t, "text/plain", headers.Get("Content-Type"))
 }
 
+func TestCopyRequestHeaders(t *testing.T) {
+	headers := http.Header{
+		"Accept":        []string{"application/json"},
+		"Authorization": []string{"Bearer token"},
+		"X-Trace-Id":    []string{"abc123"},
+		"User-Agent":    []string{"curl/8.0"},
+	}
+
+	forwardedHeaders := copyRequestHeaders(headers)
+
+	assert.Equal(t, "application/json", forwardedHeaders["Accept"])
+	assert.Equal(t, "Bearer token", forwardedHeaders["Authorization"])
+	assert.Equal(t, "abc123", forwardedHeaders["X-Trace-Id"])
+	assert.NotContains(t, forwardedHeaders, "User-Agent")
+}
+
+func TestCopyRequestHeadersDropsHopByHopHeaders(t *testing.T) {
+	headers := http.Header{
+		"Connection":          []string{"keep-alive"},
+		"Keep-Alive":          []string{"timeout=5"},
+		"Proxy-Authenticate":  []string{"Basic"},
+		"Proxy-Authorization": []string{"Basic credentials"},
+		"Proxy-Connection":    []string{"keep-alive"},
+		"Te":                  []string{"trailers"},
+		"Trailer":             []string{"Expires"},
+		"Transfer-Encoding":   []string{"chunked"},
+		"Upgrade":             []string{"websocket"},
+		"X-Forward-Me":        []string{"yes"},
+	}
+
+	forwardedHeaders := copyRequestHeaders(headers)
+
+	assert.Equal(t, map[string]string{"X-Forward-Me": "yes"}, forwardedHeaders)
+}
+
+func TestCopyRequestHeadersDropsConnectionNamedHeaders(t *testing.T) {
+	headers := http.Header{
+		"Connection":    []string{"X-Debug, x-remove-me"},
+		"X-Debug":       []string{"debug"},
+		"X-Remove-Me":   []string{"remove"},
+		"X-Forward-Me":  []string{"keep"},
+		"Cache-Control": []string{"no-cache"},
+	}
+
+	forwardedHeaders := copyRequestHeaders(headers)
+
+	assert.Equal(t, "keep", forwardedHeaders["X-Forward-Me"])
+	assert.Equal(t, "no-cache", forwardedHeaders["Cache-Control"])
+	assert.NotContains(t, forwardedHeaders, "Connection")
+	assert.NotContains(t, forwardedHeaders, "X-Debug")
+	assert.NotContains(t, forwardedHeaders, "X-Remove-Me")
+}
+
 func TestScrapflyJA3Smoke(t *testing.T) {
 	if os.Getenv("GOTLSPROXY_SCRAPFLY_SMOKE") != "1" {
 		t.Skip("set GOTLSPROXY_SCRAPFLY_SMOKE=1 to run Scrapfly JA3 smoke test")

--- a/main_test.go
+++ b/main_test.go
@@ -171,7 +171,7 @@ func TestCopyRequestHeaders(t *testing.T) {
 		"User-Agent":    []string{"curl/8.0"},
 	}
 
-	forwardedHeaders := copyRequestHeaders(headers)
+	forwardedHeaders := copyRequestHeaders(headers, nil)
 
 	assert.Equal(t, "application/json", forwardedHeaders["Accept"])
 	assert.Equal(t, "Bearer token", forwardedHeaders["Authorization"])
@@ -193,7 +193,7 @@ func TestCopyRequestHeadersDropsHopByHopHeaders(t *testing.T) {
 		"X-Forward-Me":        []string{"yes"},
 	}
 
-	forwardedHeaders := copyRequestHeaders(headers)
+	forwardedHeaders := copyRequestHeaders(headers, nil)
 
 	assert.Equal(t, map[string]string{"X-Forward-Me": "yes"}, forwardedHeaders)
 }
@@ -207,13 +207,52 @@ func TestCopyRequestHeadersDropsConnectionNamedHeaders(t *testing.T) {
 		"Cache-Control": []string{"no-cache"},
 	}
 
-	forwardedHeaders := copyRequestHeaders(headers)
+	forwardedHeaders := copyRequestHeaders(headers, nil)
 
 	assert.Equal(t, "keep", forwardedHeaders["X-Forward-Me"])
 	assert.Equal(t, "no-cache", forwardedHeaders["Cache-Control"])
 	assert.NotContains(t, forwardedHeaders, "Connection")
 	assert.NotContains(t, forwardedHeaders, "X-Debug")
 	assert.NotContains(t, forwardedHeaders, "X-Remove-Me")
+}
+
+func TestCopyRequestHeadersKeepsAllowedHopByHopHeaders(t *testing.T) {
+	headers := http.Header{
+		"Connection":   []string{"X-Debug"},
+		"Keep-Alive":   []string{"timeout=5"},
+		"X-Debug":      []string{"debug"},
+		"Upgrade":      []string{"websocket"},
+		"X-Forward-Me": []string{"keep"},
+	}
+
+	keepHeaders := headerNames{"keep-alive", "X-Debug"}.allowList()
+	forwardedHeaders := copyRequestHeaders(headers, keepHeaders)
+
+	assert.Equal(t, "timeout=5", forwardedHeaders["Keep-Alive"])
+	assert.Equal(t, "debug", forwardedHeaders["X-Debug"])
+	assert.Equal(t, "keep", forwardedHeaders["X-Forward-Me"])
+	assert.NotContains(t, forwardedHeaders, "Connection")
+	assert.NotContains(t, forwardedHeaders, "Upgrade")
+}
+
+func TestHeaderNamesSet(t *testing.T) {
+	var headers headerNames
+
+	require.NoError(t, headers.Set(" Keep-Alive "))
+	require.NoError(t, headers.Set("X-Debug"))
+
+	assert.Equal(t, "Keep-Alive,X-Debug", headers.String())
+	assert.Equal(t, map[string]struct{}{
+		"keep-alive": {},
+		"x-debug":    {},
+	}, headers.allowList())
+}
+
+func TestHeaderNamesSetRejectsEmptyName(t *testing.T) {
+	var headers headerNames
+
+	require.Error(t, headers.Set(" "))
+	assert.Empty(t, headers)
 }
 
 func TestScrapflyJA3Smoke(t *testing.T) {


### PR DESCRIPTION
## Summary
- strip hop-by-hop and proxy-sensitive headers before forwarding requests through CycleTLS
- also strip custom headers named by the client Connection header
- add repeatable -keep-request-header for explicit opt-in forwarding of selected stripped request headers
- keep normal end-to-end headers, while still letting -ua control User-Agent
- document request header handling and the keep-header override in the README

## Tests
- GOCACHE=/Users/fopina/workspace/gotlsproxy/.gocache go test ./...
- GOCACHE=/Users/fopina/workspace/gotlsproxy/.gocache go run . -h

Addresses the hop-by-hop request header finding in #23.