### PR TITLE
Stream bodies through CycleTLS transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ $ docker run --rm ghcr.io/fopina/gotlsproxy:0.3 -version
 
 ### Response handling
 
-`gotlsproxy` uses CycleTLS for upstream requests. CycleTLS may decode compressed upstream response bodies before returning them to the proxy, so responses sent back to clients are the decoded body, not necessarily the original wire-encoded bytes. With the current CycleTLS version, `gzip`, `deflate`, `br`, and `brotli` response encodings are decoded when advertised by the upstream `Content-Encoding` header.
+`gotlsproxy` uses CycleTLS's HTTP transport for upstream requests. Response bodies are streamed from the upstream server to the client instead of being fully buffered by gotlsproxy.
 
-Because of that, `gotlsproxy` forwards upstream response headers except `Content-Encoding` and `Content-Length`. Those two headers describe the original upstream representation and can become stale after decoding; Go's HTTP server will frame the response body sent to the client.
+### Body handling
+
+`gotlsproxy` streams request bodies through CycleTLS's transport and streams upstream response bodies back to clients. This avoids full body buffering in gotlsproxy and preserves binary payloads.
 
 ### Request header handling
 

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.25.0
 
 require (
 	github.com/Danny-Dasilva/CycleTLS/cycletls v1.0.30
+	github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/net v0.55.0
+	h12.io/socks v1.0.3
 )
 
 require (
-	github.com/Danny-Dasilva/fhttp v0.0.0-20260106165651-41258808b131 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
 	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -29,13 +31,11 @@ require (
 	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	golang.org/x/text v0.37.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	h12.io/socks v1.0.3 // indirect
 )
 
 replace github.com/Danny-Dasilva/CycleTLS/cycletls => github.com/fopina/CycleTLS/cycletls v0.0.0-20260606182123-283dde567e9e

--- a/main.go
+++ b/main.go
@@ -1,16 +1,25 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
 	"flag"
 	"fmt"
 	"io"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
-	"regexp"
 	"strings"
+	"time"
 
 	"github.com/Danny-Dasilva/CycleTLS/cycletls"
+	fhttp "github.com/Danny-Dasilva/fhttp"
+	"golang.org/x/net/proxy"
+	"h12.io/socks"
 )
 
 var version string = "DEV"
@@ -23,49 +32,31 @@ var timeout int
 var printErrors bool
 var upstreamProxy string
 var keepRequestHeaders headerNames
+var newHTTPClient = newCycleTLSHTTPClient
 
-func writeError(w http.ResponseWriter, err error) {
-	w.WriteHeader(500)
+func writeError(w http.ResponseWriter, status int, err error) {
+	w.WriteHeader(status)
 	_, errWrite := w.Write([]byte(err.Error()))
 	if errWrite != nil {
 		log.Printf("ERROR Proxy2Client: %v", errWrite)
 	}
 }
 
-var htmlTagStripper = regexp.MustCompile(`<.*?>`)
-var htmlStyleScriptStripper = regexp.MustCompile(`(?s)<(style|script)\b.*>(.*?)</(style|script)>`)
-var newlineStripper = regexp.MustCompile(`(?s)\n+`)
-
-func cleanErrorResponseBody(body string) string {
-	return newlineStripper.ReplaceAllString(
-		htmlTagStripper.ReplaceAllString(
-			htmlStyleScriptStripper.ReplaceAllString(body, ""),
-			"",
-		),
-		"\n",
-	)
-}
-
-func printIfErrorCode(request *http.Request, response *cycletls.Response) {
-	if response.Status >= 400 {
-		log.Printf("Response status %d", response.Status)
+func printIfHTTPErrorCode(request *http.Request, response *fhttp.Response) {
+	if response.StatusCode >= 400 {
+		log.Printf("Response status %d", response.StatusCode)
 		log.Printf("== request ==")
 		log.Printf("%v", request)
 		log.Printf("== response ==")
-		log.Printf("%v", cycletls.Response{RequestID: response.RequestID, Status: response.Status, Body: cleanErrorResponseBody(response.Body), Headers: response.Headers})
+		log.Printf("%s %s", response.Proto, response.Status)
 	}
 }
 
-func copyResponseHeaders(dst http.Header, src map[string]string) {
-	for name, value := range src {
-		switch {
-		case strings.EqualFold(name, "Content-Encoding"):
-			continue
-		case strings.EqualFold(name, "Content-Length"):
-			continue
+func copyResponseHeaders(dst http.Header, src fhttp.Header) {
+	for name, values := range src {
+		for _, value := range values {
+			dst.Add(name, value)
 		}
-
-		dst.Add(name, value)
 	}
 }
 
@@ -150,35 +141,169 @@ func copyRequestHeaders(src http.Header, keepHeaders map[string]struct{}) map[st
 	return forwardedHeaders
 }
 
+type contextDialerFunc func(context.Context, string, string) (net.Conn, error)
+
+func (fn contextDialerFunc) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	return fn(ctx, network, address)
+}
+
+func defaultProxyPort(scheme string) string {
+	switch scheme {
+	case "http":
+		return "80"
+	case "https":
+		return "443"
+	case "socks4", "socks5", "socks5h":
+		return "1080"
+	default:
+		return ""
+	}
+}
+
+func proxyAddress(proxyURL *url.URL) string {
+	if proxyURL.Port() != "" {
+		return proxyURL.Host
+	}
+	return net.JoinHostPort(proxyURL.Hostname(), defaultProxyPort(proxyURL.Scheme))
+}
+
+func newHTTPConnectDialer(proxyURL *url.URL) proxy.ContextDialer {
+	proxyAddr := proxyAddress(proxyURL)
+	return contextDialerFunc(func(ctx context.Context, network, address string) (net.Conn, error) {
+		var dialer net.Dialer
+		conn, err := dialer.DialContext(ctx, network, proxyAddr)
+		if err != nil {
+			return nil, err
+		}
+
+		if proxyURL.Scheme == "https" {
+			tlsConn := tls.Client(conn, &tls.Config{ServerName: proxyURL.Hostname()})
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				_ = conn.Close()
+				return nil, err
+			}
+			conn = tlsConn
+		}
+
+		connectRequest := &http.Request{
+			Method: "CONNECT",
+			URL:    &url.URL{Opaque: address},
+			Host:   address,
+			Header: make(http.Header),
+		}
+		connectRequest.Header.Set("User-Agent", userAgent)
+		if proxyURL.User != nil && proxyURL.User.Username() != "" {
+			password, _ := proxyURL.User.Password()
+			token := base64.StdEncoding.EncodeToString([]byte(proxyURL.User.Username() + ":" + password))
+			connectRequest.Header.Set("Proxy-Authorization", "Basic "+token)
+		}
+
+		if err := connectRequest.Write(conn); err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		response, err := http.ReadResponse(bufio.NewReader(conn), connectRequest)
+		if err != nil {
+			_ = conn.Close()
+			return nil, err
+		}
+		if response.StatusCode != http.StatusOK {
+			_ = response.Body.Close()
+			_ = conn.Close()
+			return nil, fmt.Errorf("proxy responded with non-200 status: %s", response.Status)
+		}
+		_ = response.Body.Close()
+		return conn, nil
+	})
+}
+
+func upstreamDialer() (proxy.ContextDialer, error) {
+	if upstreamProxy == "" {
+		return proxy.Direct, nil
+	}
+
+	proxyURL, err := url.Parse(upstreamProxy)
+	if err != nil {
+		return nil, err
+	}
+
+	switch proxyURL.Scheme {
+	case "http", "https":
+		if proxyURL.Host == "" {
+			return nil, fmt.Errorf("invalid proxy URL %q", upstreamProxy)
+		}
+		return newHTTPConnectDialer(proxyURL), nil
+	case "socks4":
+		dialer := socks.DialSocksProxy(socks.SOCKS4, proxyAddress(proxyURL))
+		return contextDialerFunc(func(_ context.Context, network, address string) (net.Conn, error) {
+			return dialer(network, address)
+		}), nil
+	case "socks5", "socks5h":
+		dialer, err := proxy.FromURL(proxyURL, proxy.Direct)
+		if err != nil {
+			return nil, err
+		}
+		contextDialer, ok := dialer.(proxy.ContextDialer)
+		if !ok {
+			return nil, fmt.Errorf("proxy %s does not support context dialing", upstreamProxy)
+		}
+		return contextDialer, nil
+	case "":
+		return nil, fmt.Errorf("specify proxy scheme explicitly")
+	default:
+		return nil, fmt.Errorf("scheme %s is not supported", proxyURL.Scheme)
+	}
+}
+
+func newCycleTLSHTTPClient() (*fhttp.Client, error) {
+	dialer, err := upstreamDialer()
+	if err != nil {
+		return nil, err
+	}
+	return &fhttp.Client{
+		Transport: cycletls.NewTransportWithProxy(ja3, userAgent, dialer),
+		Timeout:   time.Duration(timeout) * time.Second,
+	}, nil
+}
+
+func copyRequestHeadersToFHTTP(dst fhttp.Header, src http.Header, keepHeaders map[string]struct{}) {
+	for name, value := range copyRequestHeaders(src, keepHeaders) {
+		dst.Set(name, value)
+	}
+}
+
 func hello(w http.ResponseWriter, req *http.Request) {
-	client := cycletls.Init()
-
-	body, err := io.ReadAll(req.Body)
+	client, err := newHTTPClient()
 	if err != nil {
-		writeError(w, err)
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 
-	response, err := client.Do(fmt.Sprintf("%s%s", mainURL, req.URL), cycletls.Options{
-		Body:      string(body),
-		Ja3:       ja3,
-		UserAgent: userAgent,
-		Headers:   copyRequestHeaders(req.Header, keepRequestHeaders.allowList()),
-		Timeout:   timeout,
-		Proxy:     upstreamProxy,
-	}, req.Method)
+	upstreamRequest, err := fhttp.NewRequestWithContext(req.Context(), req.Method, fmt.Sprintf("%s%s", mainURL, req.URL), req.Body)
 	if err != nil {
-		writeError(w, err)
+		writeError(w, http.StatusInternalServerError, err)
 		return
 	}
+	copyRequestHeadersToFHTTP(upstreamRequest.Header, req.Header, keepRequestHeaders.allowList())
+
+	response, err := client.Do(upstreamRequest)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	defer func() {
+		if err := response.Body.Close(); err != nil {
+			log.Printf("ERROR UpstreamResponseClose: %v", err)
+		}
+	}()
 
 	if printErrors {
-		printIfErrorCode(req, &response)
+		printIfHTTPErrorCode(req, response)
 	}
 
-	copyResponseHeaders(w.Header(), response.Headers)
-	w.WriteHeader(response.Status)
-	_, err = w.Write([]byte(response.Body))
+	copyResponseHeaders(w.Header(), response.Header)
+	w.WriteHeader(response.StatusCode)
+	_, err = io.Copy(w, response.Body)
 	if err != nil {
 		log.Printf("ERROR Proxy2Client: %v", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"encoding/json"
-	"log"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Danny-Dasilva/CycleTLS/cycletls"
+	fhttp "github.com/Danny-Dasilva/fhttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +37,12 @@ type smokeFingerprint struct {
 	pointFormats  string
 	reportedJA3   string
 	reportedJA3MD string
+}
+
+type roundTripFunc func(*fhttp.Request) (*fhttp.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *fhttp.Request) (*fhttp.Response, error) {
+	return fn(req)
 }
 
 func fetchScrapflyJA3(t *testing.T, client *http.Client, url string) scrapflyJA3Response {
@@ -73,75 +78,13 @@ func fetchUserAgent(t *testing.T, client *http.Client, url string) string {
 	return echoed.UserAgent
 }
 
-func TestPrintIfErrorCode200(t *testing.T) {
-	var buf bytes.Buffer
-	log.SetFlags(0)
-	log.SetOutput(&buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	var response = cycletls.Response{
-		RequestID: "1",
-		Status:    200,
-		Body:      "test",
-		Headers:   nil,
-	}
-	printIfErrorCode(nil, &response)
-	assert.Equal(t, "", buf.String())
-}
-
-func TestPrintIfErrorCode400(t *testing.T) {
-	var buf bytes.Buffer
-	log.SetFlags(0)
-	log.SetOutput(&buf)
-	defer func() {
-		log.SetOutput(os.Stderr)
-	}()
-
-	var response = cycletls.Response{
-		RequestID: "1",
-		Status:    404,
-		Body:      `not found`,
-		Headers:   nil,
-	}
-	printIfErrorCode(nil, &response)
-	assert.Equal(t, `Response status 404
-== request ==
-<nil>
-== response ==
-{1 404 not found [] map[] [] }
-`, buf.String())
-}
-
-func TestCleanErrorResponseBody(t *testing.T) {
-	// random 404: curl https://www.google.com/asdasdasd
-	var raw = `<!DOCTYPE html>
-<html lang=en>
-<meta charset=utf-8>
-<meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
-<title>Error 404 (Not Found)!!1</title>
-<style>
-*{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
-</style>
-<script src="wtv">alert(123)</script>
-<a href=//www.google.com/><span id=logo aria-label=Google></span></a>
-<p><b>404.</b> <ins>That’s an error.</ins>
-<p>The requested URL <code>/asdasdasd</code> was not found on this server.  <ins>That’s all we know.</ins>`
-	var cleanError = cleanErrorResponseBody(raw)
-	assert.Equal(t, `
-Error 404 (Not Found)!!1
-404. That’s an error.
-The requested URL /asdasdasd was not found on this server.  That’s all we know.`, cleanError)
-}
-
 func TestCopyResponseHeaders(t *testing.T) {
 	headers := make(http.Header)
 
-	copyResponseHeaders(headers, map[string]string{
-		"Content-Type":  "application/json",
-		"Set-Cookie":    "session=abc; HttpOnly",
-		"Cache-Control": "no-store",
+	copyResponseHeaders(headers, fhttp.Header{
+		"Content-Type":  []string{"application/json"},
+		"Set-Cookie":    []string{"session=abc; HttpOnly"},
+		"Cache-Control": []string{"no-store"},
 	})
 
 	assert.Equal(t, "application/json", headers.Get("Content-Type"))
@@ -149,17 +92,17 @@ func TestCopyResponseHeaders(t *testing.T) {
 	assert.Equal(t, "no-store", headers.Get("Cache-Control"))
 }
 
-func TestCopyResponseHeadersDropsDecodedBodyEntityHeaders(t *testing.T) {
+func TestCopyResponseHeadersPreservesEntityHeadersForStreamingResponse(t *testing.T) {
 	headers := make(http.Header)
 
-	copyResponseHeaders(headers, map[string]string{
-		"content-encoding": "gzip",
-		"CONTENT-LENGTH":   "123",
-		"Content-Type":     "text/plain",
+	copyResponseHeaders(headers, fhttp.Header{
+		"Content-Encoding": []string{"gzip"},
+		"Content-Length":   []string{"123"},
+		"Content-Type":     []string{"text/plain"},
 	})
 
-	assert.Empty(t, headers.Values("Content-Encoding"))
-	assert.Empty(t, headers.Values("Content-Length"))
+	assert.Equal(t, "gzip", headers.Get("Content-Encoding"))
+	assert.Equal(t, "123", headers.Get("Content-Length"))
 	assert.Equal(t, "text/plain", headers.Get("Content-Type"))
 }
 
@@ -233,6 +176,87 @@ func TestCopyRequestHeadersKeepsAllowedHopByHopHeaders(t *testing.T) {
 	assert.Equal(t, "keep", forwardedHeaders["X-Forward-Me"])
 	assert.NotContains(t, forwardedHeaders, "Connection")
 	assert.NotContains(t, forwardedHeaders, "Upgrade")
+}
+
+func TestHelloStreamsUpstreamResponse(t *testing.T) {
+	oldMainURL := mainURL
+	oldUserAgent := userAgent
+	oldJA3 := ja3
+	oldTimeout := timeout
+	oldPrintErrors := printErrors
+	oldUpstreamProxy := upstreamProxy
+	oldNewHTTPClient := newHTTPClient
+	defer func() {
+		mainURL = oldMainURL
+		userAgent = oldUserAgent
+		ja3 = oldJA3
+		timeout = oldTimeout
+		printErrors = oldPrintErrors
+		upstreamProxy = oldUpstreamProxy
+		newHTTPClient = oldNewHTTPClient
+	}()
+
+	firstChunkWritten := make(chan struct{})
+	allowSecondChunk := make(chan struct{})
+	responseBodyReader, responseBodyWriter := io.Pipe()
+	newHTTPClient = func() (*fhttp.Client, error) {
+		return &fhttp.Client{Transport: roundTripFunc(func(_ *fhttp.Request) (*fhttp.Response, error) {
+			go func() {
+				_, err := responseBodyWriter.Write([]byte("first"))
+				require.NoError(t, err)
+				close(firstChunkWritten)
+				<-allowSecondChunk
+				_, err = responseBodyWriter.Write([]byte("second"))
+				require.NoError(t, err)
+				require.NoError(t, responseBodyWriter.Close())
+			}()
+			return &fhttp.Response{
+				Status:        "200 OK",
+				StatusCode:    http.StatusOK,
+				Proto:         "HTTP/1.1",
+				ProtoMajor:    1,
+				ProtoMinor:    1,
+				Header:        fhttp.Header{"Content-Type": []string{"text/plain"}},
+				Body:          responseBodyReader,
+				ContentLength: -1,
+			}, nil
+		})}, nil
+	}
+
+	mainURL = "http://example.test"
+	userAgent = "gotlsproxy-test"
+	ja3 = ""
+	timeout = 10
+	printErrors = false
+	upstreamProxy = ""
+
+	recorder := httptest.NewRecorder()
+	handlerDone := make(chan struct{})
+	go func() {
+		hello(recorder, httptest.NewRequest(http.MethodGet, "/", nil))
+		close(handlerDone)
+	}()
+
+	<-firstChunkWritten
+
+	require.Eventually(t, func() bool {
+		return recorder.Body.String() == "first"
+	}, time.Second, 10*time.Millisecond)
+
+	select {
+	case <-handlerDone:
+		close(allowSecondChunk)
+		t.Fatal("handler completed before upstream stream completed")
+	default:
+	}
+
+	close(allowSecondChunk)
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not complete after upstream stream completed")
+	}
+	assert.Equal(t, "firstsecond", recorder.Body.String())
 }
 
 func TestHeaderNamesSet(t *testing.T) {


### PR DESCRIPTION
## Summary
- switch proxying from CycleTLS.Do to CycleTLS HTTP transport streaming
- remove buffered response inspection and decoding assumptions
- keep upstream proxy support while streaming request and response bodies

## Verification
- GOCACHE=/Users/fopina/workspace/gotlsproxy/.gocache go test ./...

Addresses the remaining medium body buffering item in #23.