### PR TITLE
Fix release workflow tag trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: 🎉 Release Binary
 on:
-  create:
+  push:
     tags:
       - v*
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- switch the release workflow from the broad create event to push tag filtering
- keep manual workflow_dispatch support

## Context
Recent GitHub Actions history showed release.yml running on branch creation events such as issue-4-forward-proxy and issue-23-ci-tests. Using push.tags limits automatic release runs to pushed v* tags.

## Testing
- not run; workflow trigger-only change